### PR TITLE
Pin pnpm 11.7.0 for CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,5 @@
     "typescript": "^5.9.3",
     "wrangler": "^4.110.0"
   },
-  "packageManager": "pnpm@11.12.0"
+  "packageManager": "pnpm@11.7.0"
 }


### PR DESCRIPTION
## Summary

- pin the repository package manager to `pnpm@11.7.0`
- keep GitHub Actions and local installs on the same pnpm release

## Why

GitHub Actions failed while switching from pnpm 11.7.0 to 11.12.0 with `Cannot use 'in' operator to search for 'integrity' in undefined`. Keeping the repository on 11.7.0 avoids that failing lockfile conversion path.

## Validation

- forced frozen-lockfile install completes with pnpm 11.7.0
- `pnpm lint` passes with one pre-existing accessibility warning
- `pnpm cf:build` passes under pnpm 11.7.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s package manager version specification for improved tooling compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->