### PR TITLE
Document TypeScript and pnpm version pins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Repository Agent Instructions
+
+## Dependency updates
+
+- Keep TypeScript on major version 6 because the project uses Next.js. Do not upgrade `typescript` to version 7 unless Next.js compatibility is explicitly reviewed and approved.
+- Keep the package manager pinned to exactly `pnpm@11.7.0` because the GitHub Actions workflows depend on that version. Do not upgrade pnpm unless the workflows are updated and verified at the same time.


### PR DESCRIPTION
## Summary
- document the intentional TypeScript 6 constraint for Next.js
- document the pnpm 11.7.0 pin used by GitHub Actions

## Verification
- git diff --check