### PR TITLE
Remove redundant dependency overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@types/react': 19.2.14
-  '@types/react-dom': 19.2.3
-
 importers:
 
   .:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,6 @@ settings:
 overrides:
   '@types/react': 19.2.14
   '@types/react-dom': 19.2.3
-  postcss: 8.5.16
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,4 +5,3 @@ allowBuilds:
 overrides:
   "@types/react": "19.2.14"
   "@types/react-dom": "19.2.3"
-  postcss: "8.5.16"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,3 @@ allowBuilds:
   esbuild: true
   sharp: true
   workerd: true
-overrides:
-  "@types/react": "19.2.14"
-  "@types/react-dom": "19.2.3"


### PR DESCRIPTION
## Summary

- remove the explicit PostCSS version override
- remove redundant React type overrides already enforced by exact devDependency versions
- retain pnpm build-script allowlisting

## Verification

- `pnpm install --lockfile-only`
- `pnpm build` (Node 26.3.1)
- `git diff --check`